### PR TITLE
Arc camera system

### DIFF
--- a/Source/YTE/Graphics/Camera.hpp
+++ b/Source/YTE/Graphics/Camera.hpp
@@ -144,7 +144,7 @@ namespace YTE
       mZoomMin = aDist.x;
     }
 
-    glm::vec2 GetZoomingMaxAndMin()
+    glm::vec2 GetZoomingMaxAndMin() const
     {
       return glm::vec2(mZoomMin, mZoomMax);
     }
@@ -178,6 +178,8 @@ namespace YTE
     float mZoom;
     float mZoomMin;
     float mZoomMax;
+    float mMoveUp;
+    float mMoveRight;
  
  
     bool mConstructing; 


### PR DESCRIPTION
The camera now has a full Arcball Camera system similar to Maya. The controls are:

- ALT + Left Mouse + Mouse Drag: Camera Rotation
- ALT + Right Mouse + Mouse Drag: Drag forward and backward to zoom in and out
- ALT + Middle Mouse + Mouse Drag: Camera Panning
- Scroll Wheel: Zooms in and out

There is an additional control in the editor under the camera component for the min and max zooming distances.
Fixed the oval feeling the rotation was doing.
Fixed the world being upside down
Fixed bug when camera was at the origin you couldnt move
Fixed issue when the camera reaches the north and south poles, and it kinda freaks out.
