### PR TITLE
Materials Naming Convention Removal

### DIFF
--- a/Source/YTE/Graphics/Generics/Mesh.cpp
+++ b/Source/YTE/Graphics/Generics/Mesh.cpp
@@ -223,7 +223,9 @@ namespace YTE
 
     mName = aMesh->mName.C_Str();
     mMaterialName = name.C_Str();
-    mShaderSetName = mMaterialName.substr(0, mMaterialName.find_first_of('_'));
+
+    // TODO (Andrew): Add ability to provide a shader if wanted
+    //mShaderSetName = mMaterialName.substr(0, mMaterialName.find_first_of('_'));
 
     aiString diffuse;
     aiString specular;


### PR DESCRIPTION
Removed the need to name the materials. The correct shader will be chosen based on the maps provided by the shader.